### PR TITLE
Fix deprecations with newer versions of pydata stack

### DIFF
--- a/gdsctools/anova_report.py
+++ b/gdsctools/anova_report.py
@@ -30,6 +30,7 @@ from gdsctools.readers import DrugDecode
 import pandas as pd
 import pylab
 import numpy as np
+import matplotlib.ticker as mticker
 
 from easydev import Progress
 import easydev
@@ -403,6 +404,7 @@ class ANOVAReport(object):
         ax.set_yticklabels(labels, fontsize=12)
 
         xticks = ax.get_xticks()
+        ax.xaxis.set_major_locator(mticker.FixedLocator(xticks))
         ax.set_xticklabels(
                 [int(x) if divmod(x,1)[1] == 0 else "" for x in xticks])
 

--- a/gdsctools/logistics.py
+++ b/gdsctools/logistics.py
@@ -369,7 +369,7 @@ class LogisticMatchedFiltering(object):
         pylab.clf()
         pylab.contourf(results.transpose(), 20,
                 extent=[xmid_range[0], xmid_range[-1],
-                scale_range[0], scale_range[-1]], aspect='auto')
+                scale_range[0], scale_range[-1]])
         pylab.plot(coords[0], coords[1], 'ko')
         pylab.colorbar()
 

--- a/gdsctools/qvalue.py
+++ b/gdsctools/qvalue.py
@@ -79,7 +79,7 @@ class QValue(object):
 
         if lambdas is None:
             epsilon = 1e-8
-            lambdas = scipy.arange(0,0.9+1e-8,0.05)
+            lambdas = np.arange(0,0.9+1e-8,0.05)
 
         if len(lambdas)>1 and len(lambdas)<4:
             raise ValueError("""if length of lambda greater than 1, you need at least 4 values""")
@@ -159,7 +159,7 @@ class QValue(object):
     def qvalue(self):
         """Return the qvalues using pvalues stored in :attr:`pv` attribute"""
         pv = self.pv.ravel()
-        p_ordered = scipy.argsort(pv)
+        p_ordered = np.argsort(pv)
         pv = pv[p_ordered]
         qv = self.pi0 * self.m/len(pv) * pv
         qv[-1] = min(qv[-1],1.0)
@@ -168,7 +168,7 @@ class QValue(object):
             qv[i] = min(self.pi0*self.m*pv[i]/(i+1.0), qv[i+1])
         # reorder qvalues
         qv_temp = qv.copy()
-        qv = scipy.zeros_like(qv)
+        qv = np.zeros_like(qv)
         qv[p_ordered] = qv_temp
 
         # reshape qvalues

--- a/gdsctools/regression.py
+++ b/gdsctools/regression.py
@@ -609,7 +609,7 @@ class Regression(BaseModels):
 
         return results
 
-    def dendogram_coefficients(self, stacked=False, show=True, cmap="terrain"):
+    def dendogram_coefficients(self, stacked=False, show=False, cmap="terrain"):
         """
 
         shows the coefficient of each optimised model for each drug
@@ -622,6 +622,7 @@ class Regression(BaseModels):
         from easydev import Progress
         pb = Progress(len(drugids))
         d = {}
+        show = False
 
         for i, drug_name in enumerate(drugids):
             X, Y = self._get_one_drug_data(drug_name, randomize_Y=False)
@@ -635,10 +636,10 @@ class Regression(BaseModels):
         dfall = pd.concat([d[i] for i in drugids], axis=1)
         dfall.columns = drugids
 
-        if show:
-            from biokit import heatmap
-            h = heatmap.Heatmap(dfall, cmap=cmap)
-            h.plot(num=1,colorbar_position="top left")
+        # if show:
+        #     from biokit import heatmap
+        #     h = heatmap.Heatmap(dfall, cmap=cmap)
+        #     h.plot(num=1,colorbar_position="top left")
 
         if stacked is True:
             dfall = dfall.stack().reset_index()
@@ -998,7 +999,7 @@ def barplot(df, colname, color="sign",colors=("b", "r"),
     df.loc[df['sign'] == True, 'sign'] = 'r'
     df.loc[df['sign'] == False, 'sign'] = 'b'
 
-    colors = "".join(df['sign'])
+    colors = list(df['sign'])
 
     if len(df) < Nmax:
         df.plot(y=colname, kind=kind, color=colors, width=1, lw=1,

--- a/gdsctools/regression.py
+++ b/gdsctools/regression.py
@@ -609,7 +609,7 @@ class Regression(BaseModels):
 
         return results
 
-    def dendogram_coefficients(self, stacked=False, show=False, cmap="terrain"):
+    def dendogram_coefficients(self, stacked=False, show=True, cmap="terrain"):
         """
 
         shows the coefficient of each optimised model for each drug
@@ -622,7 +622,6 @@ class Regression(BaseModels):
         from easydev import Progress
         pb = Progress(len(drugids))
         d = {}
-        show = False
 
         for i, drug_name in enumerate(drugids):
             X, Y = self._get_one_drug_data(drug_name, randomize_Y=False)
@@ -636,10 +635,10 @@ class Regression(BaseModels):
         dfall = pd.concat([d[i] for i in drugids], axis=1)
         dfall.columns = drugids
 
-        # if show:
-        #     from biokit import heatmap
-        #     h = heatmap.Heatmap(dfall, cmap=cmap)
-        #     h.plot(num=1,colorbar_position="top left")
+        if show:
+            from biokit import heatmap
+            h = heatmap.Heatmap(dfall, cmap=cmap)
+            h.plot(num=1,colorbar_position="top left")
 
         if stacked is True:
             dfall = dfall.stack().reset_index()

--- a/gdsctools/tools.py
+++ b/gdsctools/tools.py
@@ -69,6 +69,9 @@ class Savefig(object):
 
         if size_inches is not None:
             fig.set_size_inches(size_inches)
+        elif 'set_inches' in kargs:
+            newsize = kargs.pop('set_inches')
+            fig.set_size_inches(*newsize)
         else:
             fig.set_size_inches(10, 10)
         if self.verbose:


### PR DESCRIPTION
This PR fixes a few deprecation warnings with newer versions of numpy, scipy and matplotlib.
Tested with numpy==1.21.2, scipy==1.7.1 and matplotlib==3.4.3